### PR TITLE
Call session.reload instead of webview reload to reset sessions

### DIFF
--- a/MasterApp/Modules/Screens/Base/BaseVisitableViewController.swift
+++ b/MasterApp/Modules/Screens/Base/BaseVisitableViewController.swift
@@ -18,10 +18,6 @@ class BaseVisitableViewController: Turbolinks.VisitableViewController {
     ]
 
     // MARK: Public
-    func refresh() {
-        visitableView.webView?.reload()
-    }
-
     func scrollToTop() {
         visitableView.webView?.scrollView.setContentOffset(CGPointMake(0, 0), animated: true)
         visitableView.webView?.scrollView.scrollsToTop = true

--- a/MasterApp/Modules/Screens/Base/CustomTabbarViewController.swift
+++ b/MasterApp/Modules/Screens/Base/CustomTabbarViewController.swift
@@ -39,9 +39,7 @@ class CustomTabbarViewController: UITabBarController {
         for vc : UIViewController in viewControllers {
             if let nav = vc as? TurbolinksNavigationController {
                 nav.popToRootViewControllerAnimated(false)
-                if let visistableViewController = nav.topViewController as? BaseVisitableViewController {
-                    visistableViewController.refresh()
-                }
+                nav.reset()
             }
         }
         let homeIndex = 0

--- a/MasterApp/Modules/Screens/Base/TurbolinksNavigationController.swift
+++ b/MasterApp/Modules/Screens/Base/TurbolinksNavigationController.swift
@@ -28,6 +28,10 @@ class TurbolinksNavigationController: UINavigationController {
     }()
 
     // MARK: public
+    func reset() {
+        session.reload()
+    }
+    
     func visit(URL: NSURL) {
         showVisitableForSession(session, URL: URL)
     }


### PR DESCRIPTION
[**URGENTE**] É parecido com o erro abaixo, mas o que ocorreu foi a tab de Minhas receitas permanecer com a sessão do usuário (logado) mesmo após realizar o logout (na home o logout ocorreu). Mas, ao atualizar Minhas receitas o usuário ficou logado na home home/Webview mas não no App. Vide: **http://g.recordit.co/pueYYvny45.gif**

[**URGENTE**] Após realizar logout o cache da home é limpo, mas o de Minhas Receitas não. Vide: http://g.recordit.co/LTCs0kDCn1.gif. Regra, após o logout, limpar o cache de todas as abas R tirar o parâmetro de token das URLs.